### PR TITLE
Supported farebasis codes for MOW-KZN, MOW-ROV, HBR-UUS

### DIFF
--- a/fareFamilies/SU.json
+++ b/fareFamilies/SU.json
@@ -214,7 +214,7 @@
     {
         "owner": "SU",
         "baseClass": "economy",
-        "tariffCodePattern": "^([YBMUKHLQTEN](CL|CO))\\w*\\d*$",
+        "tariffCodePattern": "^([YBMUKHLQTEN](CL|CO|FL|FX))\\w*\\d*$",
         "parameters": [
             {
                 "code": "description",


### PR DESCRIPTION
У Аэрофлота для перелетов между городами Москва и Казань, Ростов-на-Дону, между городами Хабаровск и Южно-Сахалинск действуют особые условия применения тарифов. Касается только семейства Оптимум-Эконом. Для того, чтобы поддержать эти условия достаточно расширить паттерн определения семейства/бренда, так как в тексте правил не приводятся точные величины штрафов за обмен/возврат.

Общие правила: https://www.aeroflot.ru/ru-ru/information/purchase/rate/fare_rules
Правила для указанных направлений: https://admin.aeroflot.ru/ru-ru/important_information/new_kzn_rov_hbr_uus_rules